### PR TITLE
Pull in upstream changes for Grav 1.7 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.8.1
+## 01/15/2021
+
+1. [](#improved)
+    * Fixed autoescaping in preparation for Grav 1.7
+
 # v1.8.0
 ## 03/21/2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.8.2
+## 02/25/2021
+
+1. [](#bugfix)
+    * Fixed bad tab causing invalid blueprint [#91](https://github.com/getgrav/grav-theme-learn2/pull/91)
+
 # v1.8.1
 ## 01/15/2021
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,7 @@
 name: Learn2
-version: 1.8.0
+slug: learn2
+type: theme
+version: 1.8.1
 description: "Learn2 is a new modern documentation theme for Grav"
 icon: book
 author:

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,7 +1,7 @@
 name: Learn2
 slug: learn2
 type: theme
-version: 1.8.1
+version: 1.8.2
 description: "Learn2 is a new modern documentation theme for Grav"
 icon: book
 author:

--- a/learn2.yaml
+++ b/learn2.yaml
@@ -1,5 +1,5 @@
 enabled: true
-root_page: 					                        # optional: set root page of documentation
+root_page:                                          # optional: set root page of documentation
 top_level_version: false                            # Use versions for top level navigation
 show_all_pages: false                               # Show all pages without having to 'open' them
 google_analytics_code:                              # Enter your `UA-XXXXXXXX-X` code here

--- a/templates/chapter.html.twig
+++ b/templates/chapter.html.twig
@@ -3,7 +3,7 @@
 {% block content %}
 	<div id="chapter">
     	<div id="body-inner">
-			{{ page.content }}
+			{{ page.content|raw }}
 		</div>
     </div>
 {% endblock %}

--- a/templates/error.html.twig
+++ b/templates/error.html.twig
@@ -8,7 +8,7 @@
     	<div id="body-inner">
     		<h1>{{ 'PLUGIN_ERROR.ERROR'|t }} {{ header.http_response_code }}</h1>
 
-            {{ page.content }}
+            {{ page.content|raw }}
 
 		</div>
     </div>

--- a/templates/partials/page.html.twig
+++ b/templates/partials/page.html.twig
@@ -1,6 +1,6 @@
 <div id="body-inner">
     <h1>{{ page.title }}</h1>
     <p>
-    	{{ page.content }}
+    	{{ page.content|raw }}
     </p>
 </div>

--- a/templates/partials/sidebar.html.twig
+++ b/templates/partials/sidebar.html.twig
@@ -62,7 +62,7 @@
                     class="fa fa-fw fa-history"></i> {{ 'THEME_LEARN2_CLEAR_HISTORY'|t }}</a><br/>
 
         <section id="footer">
-            <p>{{ 'THEME_LEARN2_BUILT_WITH_GRAV'|t }}</p>
+            <p>{{ 'THEME_LEARN2_BUILT_WITH_GRAV'|t|raw }}</p>
         </section>
     </div>
 </div>

--- a/templates/search.html.twig
+++ b/templates/search.html.twig
@@ -1,7 +1,7 @@
 {% embed 'partials/base.html.twig' with { github_link_position: false } %}
 
     {% block content %}
-        {{ page.content }}
+        {{ page.content|raw }}
 
         {% include 'partials/tntsearch.html.twig' with { in_page: true, placeholder: "Search the Grav documentation..." }%}
     {% endblock %}


### PR DESCRIPTION
New installs using Grav 1.7 are broken when trying to use our theme as HTML is escaped and printed as text. People who started on previous versions of Grav don't notice because the local settings are automatically set to a legacy compatibility mode when upgrading. This pulls in upstream fixes for the HTML escaping so that the theme will work in normal mode / for new installs.

Background info: https://learn.getgrav.org/16/advanced/grav-development/grav-17-upgrade-guide#twig